### PR TITLE
[CKLS-22535] propel_migration table is still using ENGINE=MyIsam on create new instance

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   },
   "require": {
     "php": "^7.2.5|^8.3",
-    "propel/propel1": "^5.0.2",
+    "propel/propel1": "5.0.2.1",
     "symfony/framework-bundle": "^5.4",
     "symfony/flex": "^1.0",
     "symfony/console": "^5.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a84307a72fc12f7c4fbc22351588d8a9",
+    "content-hash": "aad16ccf3e66962b4097471635c379ea",
     "packages": [
         {
             "name": "phing/phing",
@@ -120,11 +120,11 @@
         },
         {
             "name": "propel/propel1",
-            "version": "5.0.2",
+            "version": "5.0.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/CrossKnowledge/Propel.git",
-                "reference": "a4fad3ef9d18f66d6a1803c6b09cdbbd4637e445"
+                "reference": "543b44dbbed4f9296b15b09f45ba536a0740ab16"
             },
             "require": {
                 "phing/phing": "~2.4",
@@ -169,7 +169,7 @@
                 "orm",
                 "persistence"
             ],
-            "time": "2025-09-16T12:11:41+00:00"
+            "time": "2025-09-19T10:40:51+00:00"
         },
         {
             "name": "psr/cache",


### PR DESCRIPTION
https://mco365.atlassian.net/browse/CKLS-22535

This pull request updates the dependency version for `propel/propel1` in the `composer.json` file to ensure compatibility or to include important fixes.

Dependency update:

* Updated the required version of `propel/propel1` from `^5.0.2` to `5.0.2.1` in `composer.json`, which may address specific compatibility or bug fix needs.